### PR TITLE
fixed error for solc version 0.4.25

### DIFF
--- a/solc_helper
+++ b/solc_helper
@@ -8,7 +8,7 @@ end
 
 
 def compile_solidity(file)
-  json_string = `solc --add-std --optimize --combined-json abi,bin,userdoc,devdoc #{file}`
+  json_string = `solc --optimize --combined-json abi,bin,userdoc,devdoc #{file}`
   json_string = json_string.gsub("\\n","")
   begin
     json_object = JSON.parse(json_string)


### PR DESCRIPTION
Currently running solc_helper gives the following error:
unrecognised option '--add-std'

Fixed by removing this option.
Removed parameter from the solc command that is not part of the current solidity compiler, 0.4.25+commit.59dbf8f1.Linux.g++